### PR TITLE
Remove WriteCompare in PWM constructor

### DIFF
--- a/API_Python/digital.py
+++ b/API_Python/digital.py
@@ -195,7 +195,6 @@ class PWM(object):
 
         self.max_num = pow(2,self.resolution_in_bits) - 1
         self.period = self.ReadPeriod()
-        self.WriteCompare(4500)
         self.cmp = self.ReadCompare() 
 
         if self.address in RPiSoC.REGISTERS_IN_USE:


### PR DESCRIPTION
The PWM constructors in the PSoC Creator project default the Compare value to 4500. Since the Python API PWM constructor sets this explicitly, there is no danger in removing it from the Python API. In addition, it is important to explicitly not set it in the constructor so that multiple instances of a PWM object do not overwrite the running behavior.
